### PR TITLE
Fix app center deploy

### DIFF
--- a/azure/stages/deploy-appcenter.yml
+++ b/azure/stages/deploy-appcenter.yml
@@ -161,6 +161,7 @@ stages:
       runOnce:
         deploy:
           steps:
+            - checkout: self
             # If the keystore has been specified, download it from secure files
             - task: DownloadSecureFile@1
               displayName: Download keystore from Secure Files (for repackaging AAB to APK)

--- a/azure/stages/deploy-appcenter.yml
+++ b/azure/stages/deploy-appcenter.yml
@@ -145,10 +145,10 @@ stages:
   - name: application_fullpath
     value: '$(Pipeline.Workspace)/${{ parameters.artifact_name }}/${{ parameters.artifact_folder }}/${{ parameters.application_package }}'
   - name: release_notes_fullpath
-  ${{ if eq(parameters.appcenter_release_notes_source, 'artifact') }}:
-    value: '$(Pipeline.Workspace)/${{ parameters.artifact_name }}/${{ parameters.artifact_folder }}/${{ parameters.appcenter_release_notes_file }}'
-  ${{ if eq(parameters.appcenter_release_notes_source, 'source_control') }}:
-    value: '$(Build.SourcesDirectory)/${{ parameters.appcenter_release_notes_file }}'
+    ${{ if eq(parameters.appcenter_release_notes_source, 'artifact') }}:
+      value: '$(Pipeline.Workspace)/${{ parameters.artifact_name }}/${{ parameters.artifact_folder }}/${{ parameters.appcenter_release_notes_file }}'
+    ${{ if eq(parameters.appcenter_release_notes_source, 'source_control') }}:
+      value: '$(Build.SourcesDirectory)/${{ parameters.appcenter_release_notes_file }}'
 
   pool:
     vmImage: 'windows-latest'


### PR DESCRIPTION
the identation where the variables are defined for the appcenter deployment has been corrected, this error was incorporated in #37 by #36. 

For some reason the app center deploy stage not has $(Build.SourcesDirectory) with the files, so I added the checkout task.

This PR solves the problem because I have already tested by referencing this branch in the pipeline.

Sorry & thanks